### PR TITLE
Fix common-vfs class loading issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,10 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-vfs2</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -195,6 +199,12 @@
             <groupId>org.wso2.ei</groupId>
             <artifactId>integration-test-utils</artifactId>
             <version>${product.ei.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-vfs2</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.wso2.ei</groupId>
@@ -245,11 +255,42 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>shade-vfs2</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.wso2.org.apache.commons:commons-vfs2</include>
+                                    <include>org.wso2.org.apache.commons:commons-vfs2-sandbox</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.commons.vfs2</pattern>
+                                    <shadedPattern>shaded.org.apache.commons.vfs2</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>shaded</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>email-library</id>
-                        <phase>compile</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/src/main/assembly/assemble-connector.xml
+++ b/src/main/assembly/assemble-connector.xml
@@ -26,14 +26,25 @@
         <fileSet>
             <directory>target/connector/dependencies</directory>
             <outputDirectory>lib</outputDirectory>
+            <excludes>
+                <exclude>commons-email-1.2.jar</exclude>
+            </excludes>
         </fileSet>
         <fileSet>
             <directory>target/classes</directory>
             <outputDirectory></outputDirectory>
             <excludes>
+                <exclude>org/**</exclude>
                 <exclude>**/metrics_module.xml</exclude>
                 <exclude>**/META-INF/*</exclude>
             </excludes>
         </fileSet>
     </fileSets>
+    <files>
+        <file>
+            <source>target/mi-connector-file-${project.version}-shaded.jar</source>
+            <outputDirectory>lib</outputDirectory>
+            <destName>mi-connector-file-${project.version}-shaded.jar</destName>
+        </file>
+    </files>
 </assembly>

--- a/src/main/resources/META-INF/vfs-providers.xml
+++ b/src/main/resources/META-INF/vfs-providers.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one or more
+   contributor license agreements.  See the NOTICE file distributed with
+   this work for additional information regarding copyright ownership.
+   The ASF licenses this file to You under the Apache License, Version 2.0
+   (the "License"); you may not use this file except in compliance with
+   the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+  -->
+<providers>
+
+	<provider class-name="shaded.org.apache.commons.vfs2.provider.smb.SmbFileProvider">
+		<scheme name="smb"/>
+		<if-available class-name="jcifs.smb.SmbFile"/>
+	</provider>
+
+	<provider class-name="shaded.org.apache.commons.vfs2.provider.mime.MimeFileProvider">
+		<scheme name="mime"/>
+		<if-available class-name="javax.mail.internet.MimeMultipart"/>
+	</provider>
+
+	<extension-map extension="mime" scheme="mime"/>
+	<mime-type-map mime-type="message/rfc822" scheme="mime"/>
+
+</providers>

--- a/src/main/resources/shaded/org/apache/commons/vfs2/impl/providers.xml
+++ b/src/main/resources/shaded/org/apache/commons/vfs2/impl/providers.xml
@@ -1,0 +1,188 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<providers>
+    <default-provider class-name="shaded.org.apache.commons.vfs2.provider.url.UrlFileProvider">
+    </default-provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.local.DefaultLocalFileProvider">
+        <scheme name="file"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.zip.ZipFileProvider">
+        <scheme name="zip"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tar"/>
+        <if-available class-name="org.apache.commons.compress.archivers.tar.TarArchiveOutputStream"/>
+    </provider>
+
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.bzip2.Bzip2FileProvider">
+        <scheme name="bz2"/>
+        <if-available class-name="org.apache.commons.compress.compressors.bzip2.BZip2CompressorInputStream"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.gzip.GzipFileProvider">
+        <scheme name="gz"/>
+    </provider>
+
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.jar.JarFileProvider">
+        <scheme name="jar"/>
+        <scheme name="sar"/>
+        <scheme name="ear"/>
+        <scheme name="par"/>
+        <scheme name="ejb3"/>
+        <scheme name="war"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.temp.TemporaryFileProvider">
+        <scheme name="tmp"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.ftp.FtpFileProvider">
+        <scheme name="ftp"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.ftps.FtpsFileProvider">
+        <scheme name="ftps"/>
+        <if-available class-name="org.apache.commons.net.ftp.FTPFile"/>
+    </provider>
+
+    <!-- http/https providers based on HttpClient v5 -->
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http5.Http5FileProvider">
+        <scheme name="http"/>
+        <if-available class-name="org.apache.hc.client5.http.classic.HttpClient"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http5s.Http5sFileProvider">
+        <scheme name="https"/>
+        <if-available class-name="org.apache.hc.client5.http.classic.HttpClient"/>
+    </provider>
+
+    <!-- The default http3/http3s providers based on HttpClient v3 -->
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http.HttpFileProvider">
+        <scheme name="http3"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.https.HttpsFileProvider">
+        <scheme name="http3s"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+    </provider>
+
+    <!-- http4/http4s providers based on HttpClient v4 -->
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http4.Http4FileProvider">
+        <scheme name="http4"/>
+        <if-available class-name="org.apache.http.client.HttpClient"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http4s.Http4sFileProvider">
+        <scheme name="http4s"/>
+        <if-available class-name="org.apache.http.client.HttpClient"/>
+    </provider>
+
+    <!-- http5/http5s providers based on HttpClient v5 -->
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http5.Http5FileProvider">
+        <scheme name="http5"/>
+        <if-available class-name="org.apache.hc.client5.http.classic.HttpClient"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.http5s.Http5sFileProvider">
+        <scheme name="http5s"/>
+        <if-available class-name="org.apache.hc.client5.http.classic.HttpClient"/>
+    </provider>
+
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.sftp.SftpFileProvider">
+        <scheme name="sftp"/>
+        <if-available class-name="javax.crypto.Cipher"/>
+        <if-available class-name="com.jcraft.jsch.JSch"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.res.ResourceFileProvider">
+        <scheme name="res"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.webdav.WebdavFileProvider">
+        <scheme name="webdav"/>
+        <scheme name="webdav3"/>
+        <if-available class-name="org.apache.commons.httpclient.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.DavMethod"/>
+        <if-available class-name="shaded.org.apache.commons.vfs2.provider.webdav.WebdavFileSystem"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.webdav4.Webdav4FileProvider">
+        <scheme name="webdav4"/>
+        <if-available class-name="org.apache.http.client.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.BaseDavRequest"/>
+        <if-available class-name="shaded.org.apache.commons.vfs2.provider.webdav4.Webdav4FileSystem"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.webdav4s.Webdav4sFileProvider">
+        <scheme name="webdav4s"/>
+        <if-available class-name="org.apache.http.client.HttpClient"/>
+        <if-available class-name="org.apache.jackrabbit.webdav.client.methods.BaseDavRequest"/>
+        <if-available class-name="shaded.org.apache.commons.vfs2.provider.webdav4.Webdav4FileSystem"/>
+    </provider>
+    <!--
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.svn.SvnFileProvider">
+        <scheme name="svnhttps"/>
+    </provider>
+    -->
+    <!--
+        <provider class-name="shaded.org.apache.commons.vfs2.provider.tar.TgzFileProvider">
+            <scheme name="tgz"/>
+            <if-available scheme="gz"/>
+            <if-available scheme="tar"/>
+        </provider>
+        <provider class-name="shaded.org.apache.commons.vfs2.provider.tar.Tbz2FileProvider">
+            <scheme name="tbz2"/>
+            <if-available scheme="bz2"/>
+            <if-available scheme="tar"/>
+        </provider>
+    -->
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tgz"/>
+        <if-available scheme="gz"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.tar.TarFileProvider">
+        <scheme name="tbz2"/>
+        <if-available scheme="bz2"/>
+        <if-available scheme="tar"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.ram.RamFileProvider">
+        <scheme name="ram"/>
+    </provider>
+    <provider class-name="shaded.org.apache.commons.vfs2.provider.hdfs.HdfsFileProvider">
+        <scheme name="hdfs"/>
+        <if-available class-name="org.apache.hadoop.fs.FileSystem"/>
+        <if-available class-name="shaded.org.apache.commons.vfs2.provider.hdfs.HdfsFileSystem"/>
+    </provider>
+
+    <extension-map extension="zip" scheme="zip"/>
+    <extension-map extension="tar" scheme="tar"/>
+    <mime-type-map mime-type="application/zip" scheme="zip"/>
+    <mime-type-map mime-type="application/x-tar" scheme="tar"/>
+    <mime-type-map mime-type="application/x-gzip" scheme="gz"/>
+    <!--
+    <mime-type-map mime-type="application/x-tgz" scheme="tgz"/>
+    -->
+    <extension-map extension="jar" scheme="jar"/>
+    <extension-map extension="bz2" scheme="bz2"/>
+    <extension-map extension="gz" scheme="gz"/>
+    <extension-map extension="tgz" scheme="tgz"/>
+    <extension-map extension="tbz2" scheme="tbz2"/>
+
+    <!--
+    <filter-map class-name="shaded.org.apache.commons.vfs2.content.bzip2.Bzip2Compress">
+        <extension name="bz2"/>
+        <extension name="tbz2"/>
+        <if-available class-name="org.apache.commons.compress.bzip2.CBZip2InputStream"/>
+    </filter-map>
+    <filter-map class-name="shaded.org.apache.commons.vfs2.content.gzip.GzipCompress">
+        <extension name="gz"/>
+        <extension name="tgz"/>
+        <mime-type name="application/x-tgz" />
+    </filter-map>
+    -->
+</providers>


### PR DESCRIPTION
This pull request introduces several important changes to how Apache Commons VFS2 dependencies are managed and packaged in the project. The main goals are to shade the VFS2 libraries to avoid classpath conflicts, update the build process to include the shaded artifacts, and configure the assembly to use these changes. Additionally, new provider configuration files are added for the shaded VFS2 classes.
